### PR TITLE
Fix include of max86150.h

### DIFF
--- a/src/max86150.cpp
+++ b/src/max86150.cpp
@@ -7,7 +7,7 @@
   BSD license, all text above must be included in any redistribution.
  *****************************************************/
 
-#include "MAX86150.h"
+#include "max86150.h"
 
 static const uint8_t MAX86150_INTSTAT1 =		0x00;
 static const uint8_t MAX86150_INTSTAT2 =		0x01;


### PR DESCRIPTION
The file is named max86150.h (lower case letters), but it was included as MAX86150.h, causing build to fail on case sensitive operating systems such as Linux.