### PR TITLE
Fixed shutdown & wakeup functions

### DIFF
--- a/src/max86150.cpp
+++ b/src/max86150.cpp
@@ -70,8 +70,8 @@ static const uint8_t MAX86150_ROLLOVER_DISABLE = 0x00;
 
 static const uint8_t MAX86150_A_FULL_MASK = 	0xF0;
 
-static const uint8_t MAX86150_SHUTDOWN_MASK = 	0x7F;
-static const uint8_t MAX86150_SHUTDOWN = 		0x80;
+static const uint8_t MAX86150_SHUTDOWN_MASK = 	0xFD;
+static const uint8_t MAX86150_SHUTDOWN = 		0x02;
 static const uint8_t MAX86150_WAKEUP = 			0x00;
 
 static const uint8_t MAX86150_RESET_MASK = 		0xFE;


### PR DESCRIPTION
MAX86150_SHUTDOWN_MASK and MAX86150_SHUTDOWN definitions were incorrect (they were for max30102) which caused shutdown and wakeup functions not to work properly.